### PR TITLE
switch to icedtea java plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,8 @@ FROM ubuntu:14.04
 MAINTAINER Kyle Anderson <kyle@xkyle.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get -y install xvfb x11vnc wget supervisor fluxbox firefox
-
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get -y install software-properties-common && \
-    add-apt-repository -y ppa:webupd8team/java && \ 
-    apt-get update && apt-get -y install oracle-java7-installer
+RUN apt-get update && apt-get -y install xvfb x11vnc wget supervisor fluxbox \
+    firefox icedtea-7-plugin net-tools python-numpy
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 WORKDIR /root/


### PR DESCRIPTION
The webupd8team java 7 ppa is no longer available, so it's no longer possible to build this container with the current Dockerfile.  This pull request fixes this by using the version of the java plug-in that's in the official Ubuntu 14.04 repositories (which is hopefully more likely to remain available in the future).  There are some warnings about java versions when using this plug-in, but it appears to work properly with an older H8 series supermicro motherboard BMC, including a graphical KVM console and remote mounting of media.  It also adds the numpy library (requested by novnc to improve performance).