### PR TITLE
Use Chromium and reduce Java 7 security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM ubuntu:14.04
 MAINTAINER Kyle Anderson <kyle@xkyle.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get -y install software-properties-common
-RUN add-apt-repository ppa:jonathonf/firefox-esr
 RUN apt-get update && apt-get -y install xvfb x11vnc wget \
-    supervisor fluxbox icedtea-7-plugin net-tools \
-    python-numpy firefox-esr=52.9.0esr-1~14.04.york0
+    supervisor fluxbox icedtea-7-plugin net-tools python-numpy \
+    chromium-browser 
+RUN sed -e '/^jdk.jar.disabledAlgorithms/s/^/#/' -i /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/security/java.security 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 WORKDIR /root/

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -17,8 +17,8 @@ autorestart=true
 command=/usr/bin/fluxbox
 autorestart=true
 
-[program:firefox]
-command=/usr/bin/firefox
+[program:chromium]
+command=/usr/bin/chromium-browser --no-sandbox
 autorestart=true
 
 


### PR DESCRIPTION
I cloned the repo to really only make the latter change to increase IPMI compatibility, but found that the PPA used to get Firefox-ESR is no longer working. When I found no drop-in replacement, I took inspiration from the ARM Dockerfiles and built a version that uses Chromium.