### PR TITLE
Custom res

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,6 @@ WORKDIR /root/
 ADD novnc /root/novnc/
 
 ENV DISPLAY :0
+ENV RES 1024x768x24
 EXPOSE 8080
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -37,5 +37,6 @@ WORKDIR /root/
 ADD novnc /root/novnc/
 
 ENV DISPLAY :0
+ENV RES 1024x768x24
 EXPOSE 8080
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -23,5 +23,6 @@ WORKDIR /root/
 ADD novnc /root/novnc/
 
 ENV DISPLAY :0
+ENV RES 1024x768x24
 EXPOSE 8080
 CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ In your web browser you should see the firefox, ready to connect to
 and IPMI KVM:
 
 ![IPMI Screenshot](https://raw.githubusercontent.com/solarkennedy/ipmi-kvm-docker/master/screenshot.png)
+
+# Custom resolution
+
+By default, the VNC session will run with a resolution of 1024x768 (with 24-bit color depth).
+Custom resolutions can be specified with the docker environment variable RES, and must include color depth.
+
+    $ docker run -p 8080:8080 -e RES=1600x900x24 solarkennedy/ipmi-kvm-docker

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and IPMI KVM:
 
 ![IPMI Screenshot](https://raw.githubusercontent.com/solarkennedy/ipmi-kvm-docker/master/screenshot.png)
 
-# Custom resolution
+### Custom resolution
 
 By default, the VNC session will run with a resolution of 1024x768 (with 24-bit color depth).
 Custom resolutions can be specified with the docker environment variable RES, and must include color depth.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:X11]
-command=/usr/bin/Xvfb :0 -screen 0 1024x768x24
+command=/usr/bin/Xvfb :0 -screen 0 %(ENV_RES)s
 autorestart=true
 
 [program:x11vnc]

--- a/supervisord.conf.arm
+++ b/supervisord.conf.arm
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:X11]
-command=/usr/bin/Xvfb :0 -screen 0 1024x768x24
+command=/usr/bin/Xvfb :0 -screen 0 %(ENV_RES)s
 autorestart=true
 
 [program:x11vnc]


### PR DESCRIPTION
Allows custom resolutions for the headless VNC server to be passed via docker environment variables. Resolves #12