### PR TITLE
Make chrome display correctly with no warnings.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ MAINTAINER Kyle Anderson <kyle@xkyle.com>
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get -y install xvfb x11vnc wget \
     supervisor fluxbox icedtea-7-plugin net-tools python-numpy \
-    chromium-browser 
-RUN sed -e '/^jdk.jar.disabledAlgorithms/s/^/#/' -i /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/security/java.security 
+    chromium-browser
+RUN sed -e '/^jdk.jar.disabledAlgorithms/s/^/#/' -i /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/security/java.security
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 WORKDIR /root/
+RUN mkdir -p /root/images
 ADD novnc /root/novnc/
 
 ENV DISPLAY :0

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get -y install xvfb x11vnc wget \
     libcups2:armhf libexpat1:armhf libfontconfig1:armhf libudev-dev:armhf \
     libfreetype6:armhf libgdk-pixbuf2.0-0:armhf libgssapi-krb5-2:armhf \
     libgtk2.0-0:armhf libk5crypto3:armhf libkrb5-3:armhf libnss3:armhf \
-    libpango-1.0-0:armhf libpangocairo-1.0-0:armhf libpangoft2-1.0-0:armhf 
+    libpango-1.0-0:armhf libpangocairo-1.0-0:armhf libpangoft2-1.0-0:armhf
 
 
 ADD supervisord.conf.arm /etc/supervisor/conf.d/supervisord.conf
@@ -34,6 +34,7 @@ RUN dpkg -i gconf-service-backend_3.2.6-0ubuntu2_armhf.deb libgconf-2-4_3.2.6-0u
 ADD deployment.properties /root/.config/icedtea-web/deployment.properties
 
 WORKDIR /root/
+RUN mkdir -p /root/images
 ADD novnc /root/novnc/
 
 ENV DISPLAY :0

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -20,6 +20,7 @@ RUN wget http://launchpadlibrarian.net/218525709/chromium-browser_45.0.2454.85-0
 RUN dpkg -i gconf-service-backend_3.2.6-0ubuntu2_armhf.deb libgconf-2-4_3.2.6-0ubuntu2_armhf.deb gconf2-common_3.2.6-0ubuntu2_all.deb chromium-codecs-ffmpeg-extra_45.0.2454.85-0ubuntu0.14.04.1.1097_armhf.deb gconf-service_3.2.6-0ubuntu2_armhf.deb chromium-browser_45.0.2454.85-0ubuntu0.14.04.1.1097_armhf.deb
 
 WORKDIR /root/
+RUN mkdir -p /root/images
 ADD novnc /root/novnc/
 
 ENV DISPLAY :0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Docker Pulls](https://img.shields.io/docker/pulls/solarkennedy/ipmi-kvm-docker)
 
 Ever wanted to access and IPMI KVM console, only to find that you don't
-have network access or the right version of java or a compatible 
+have network access or the right version of java or a compatible
 browser or credentials?
 
 This container runs:
@@ -24,11 +24,14 @@ on the Docker Hub.
     # on a remote host that can reach ipmi
     ssh admin
     $ docker run -p 8080:8080 solarkennedy/ipmi-kvm-docker
-    
+
     # Now on your laptop
     xdg-open http://admin:8080
+    # On a mac
+    open http://admin:8080
+    # Or just open in a browser
 
-In your web browser you should see the firefox, ready to connect to 
+In your web browser you should see the firefox, ready to connect to
 and IPMI KVM:
 
 ![IPMI Screenshot](https://raw.githubusercontent.com/solarkennedy/ipmi-kvm-docker/master/screenshot.png)
@@ -39,3 +42,9 @@ By default, the VNC session will run with a resolution of 1024x768 (with 24-bit 
 Custom resolutions can be specified with the docker environment variable RES, and must include color depth.
 
     $ docker run -p 8080:8080 -e RES=1600x900x24 solarkennedy/ipmi-kvm-docker
+
+### Mount volume
+
+In case you need to mount floppy/iso images to the machine you can mount a volume to the container.
+
+    $ docker run -p 8080:8080 -v /your/local/folder:/root/images solarkennedy/ipmi-kvm-docker

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -18,7 +18,7 @@ command=/usr/bin/fluxbox
 autorestart=true
 
 [program:chromium]
-command=/usr/bin/chromium-browser --no-sandbox
+command=/usr/bin/chromium-browser --no-sandbox -test-type --window-position=0,0 --window-size=1024,722
 autorestart=true
 
 

--- a/supervisord.conf.arm
+++ b/supervisord.conf.arm
@@ -18,5 +18,5 @@ command=/usr/bin/fluxbox
 autorestart=true
 
 [program:chromium-browser]
-command=/usr/bin/chromium-browser --no-sandbox --user-data-dir --start-maximized
+command=/usr/bin/chromium-browser --no-sandbox --user-data-dir --no-sandbox -test-type --window-position=0,0 --window-size=1024,722
 autorestart=true


### PR DESCRIPTION
Some additional command line options to line up chrome browser correctly with no warnings.
Add image folder to container, so we can mount volumes.
I guess we could consider adding env vars for the chrome browser specific size/options.